### PR TITLE
feat: changes

### DIFF
--- a/ar.json
+++ b/ar.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "لا يمكنك فتح الصندوق حتى تجتاز البرنامج التعليمي للوضع الوظيفي."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "اضغط على [{key}] إلى {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "لا يمكنك السفر عندما يكون هناك لاعبون في منزلك الآمن لم يكملوا البرنامج التعليمي للوضع الوظيفي."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "أدخل الدردشة"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "اكتب رسالة..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "افتح الدردشة"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "حجم الميكروفون"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "اضغط للتحدث"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/bg.json
+++ b/bg.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Не можете да отворите сандъка, докато не преминете урока за режим на кариера."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Натиснете [{key}] за {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Не можете да пътувате, когато в убежището ви има играчи, които не са завършили урока за кариерен режим."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Влез в чата"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Напишете съобщение..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Отворете чата"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Сила на звука на микрофона"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Push to talk"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/cs.json
+++ b/cs.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Truhlu nemůžete otevřít, dokud neprojdete návodem na režim kariéry."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Stiskněte [{key}] pro {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Nemůžete cestovat, když jsou ve vašem úkrytu hráči, kteří nedokončili tutoriál pro režim kariéry."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Vstupte do chatu"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Napište zprávu..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Otevřít chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Hlasitost mikrofonu"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Push to talk"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/da.json
+++ b/da.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Du kan ikke åbne kisten, før du har bestået karrieretilstandsvejledningen."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Tryk på [{key}] for at {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Du kan ikke rejse, når der er spillere i dit safehouse, som ikke har gennemført selvstudiet til karrieretilstand."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Gå ind i chatten"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Skriv en besked..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Åbn chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofon lydstyrke"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Tryk for at tale"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/de.json
+++ b/de.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Sie können die Truhe erst öffnen, wenn Sie das Tutorial zum Karrieremodus bestanden haben."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Sie können nicht reisen, wenn sich in Ihrem Unterschlupf Spieler befinden, die das Tutorial für den Karrieremodus noch nicht abgeschlossen haben."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Betreten Sie den Chat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Eine Nachricht schreiben..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Chat öffnen"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofonlautstärke"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Push-to-talk"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/el.json
+++ b/el.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Δεν μπορείτε να ανοίξετε το στήθος μέχρι να περάσετε τον οδηγό λειτουργίας καριέρας."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Πατήστε [{key}] για να {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Δεν μπορείτε να ταξιδέψετε όταν υπάρχουν παίκτες στο ασφαλές σπίτι σας που δεν έχουν ολοκληρώσει το σεμινάριο για τη λειτουργία καριέρας."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Μπείτε στη συνομιλία"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Γράψτε ένα μήνυμα..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Ανοίξτε τη συνομιλία"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Ένταση μικροφώνου"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Σπρώξτε για να μιλήσετε"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/es.json
+++ b/es.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "No puedes abrir el cofre hasta que pases el tutorial del modo carrera."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "No puedes viajar cuando hay jugadores en tu refugio que no hayan completado el tutorial del modo carrera."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Entrar al chat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Escribir un mensaje..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "abrir chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volumen del micrófono"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Empuja para hablar"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/fi.json
+++ b/fi.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Et voi avata arkkua ennen kuin olet läpäissyt uratilan opetusohjelman."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Paina [{key}] {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Et voi matkustaa, jos turvakodissasi on pelaajia, jotka eivät ole suorittaneet uratilan opetusohjelmaa."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Siirry chatiin"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Kirjoita viesti..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Avaa chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofonin äänenvoimakkuus"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Push to talk"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/fr.json
+++ b/fr.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Vous ne pouvez pas ouvrir le coffre avant d'avoir réussi le didacticiel du mode carrière."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Vous ne pouvez pas voyager lorsqu'il y a des joueurs dans votre planque qui n'ont pas terminé le didacticiel du mode carrière.."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Entrez dans le chat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Écrivez un message..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Ouvrir le chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volume du micro"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Pousser pour parler"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/hu.json
+++ b/hu.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Nem nyithatja ki a ládát, amíg nem teljesíti a karrier mód oktatóanyagát."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Nyomja meg a [{key}], hogy {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Nem utazhat, ha olyan játékosok vannak a biztonságos házában, akik nem fejezték be a karrier mód oktatóanyagát."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Lépjen be a chatbe"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Írj üzenetet..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Nyissa meg a csevegést"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofon hangereje"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Push to talk"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/id.json
+++ b/id.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Anda tidak dapat membuka peti sampai Anda melewati tutorial mode karier."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Tekan [{key}] untuk {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Anda tidak dapat melakukan perjalanan jika ada pemain di safehouse Anda yang belum menyelesaikan tutorial untuk mode karir."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Masuk ke obrolan"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Tulis pesan..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Buka obrolan"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volume mikrofon"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Dorong untuk berbicara"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/it.json
+++ b/it.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Non puoi aprire lo scrigno finché non superi il tutorial della modalità carriera."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Premi [{key}] per {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Non puoi viaggiare quando nel tuo rifugio ci sono giocatori che non hanno completato il tutorial per la modalità carriera."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Entra nella chat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Scrivi un messaggio..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Apri la chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volume del microfono"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Spingi per parlare"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/ja.json
+++ b/ja.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "キャリアモードのチュートリアルを通過するまで宝箱を開けることはできません."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "[{key}] を押して {interact}してください"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "セーフハウスにキャリア モードのチュートリアルを完了していないプレイヤーがいる場合は旅行できません."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "チャットに入る"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "メッセージを書いてください..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "オープンチャット"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "マイクの音量"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "プッシュして話す"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/ko.json
+++ b/ko.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "커리어 모드 튜토리얼을 통과하기 전까지는 상자를 열 수 없습니다."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "{interact}하려면 [{key}]를 누르세요."
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "은신처에 커리어 모드 튜토리얼을 완료하지 않은 플레이어가 있으면 여행할 수 없습니다."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "채팅에 들어가세요"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "메시지를 작성하세요..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "오픈채팅"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "마이크 볼륨"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "눌러서 대화하기"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/nl.json
+++ b/nl.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Je kunt de kist pas openen nadat je de tutorial over de carrièremodus hebt doorlopen."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Druk op [{key}] om te {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Je kunt niet reizen als er spelers in je safehouse zijn die de tutorial voor de carrièremodus niet hebben voltooid."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Voer chat in"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Schrijf een bericht..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Chat openen"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Microfoonvolume"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Duwen om te praten"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/no.json
+++ b/no.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Du kan ikke åpne kisten før du har bestått karrieremodusopplæringen."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Trykk [{key}] for å {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Du kan ikke reise når det er spillere i safehouse som ikke har fullført opplæringen for karrieremodus."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Gå inn i chatten"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Skriv en melding..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Åpne chat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofonvolum"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Trykk for å snakke"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/pl.json
+++ b/pl.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Nie możesz otworzyć skrzyni, dopóki nie przejdziesz samouczka trybu kariery."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Naciśnij [{key}], aby {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Nie możesz podróżować, jeśli w Twojej kryjówce znajdują się gracze, którzy nie ukończyli samouczka dotyczącego trybu kariery."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Wejdź na czat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Napisz wiadomość__KROPKA____KROPKA__."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Otwórz czat"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Głośność mikrofonu"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Naciśnij, aby porozmawiać"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/pt.json
+++ b/pt.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Você não pode abrir o baú até passar no tutorial do modo carreira."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Pressione [{key}] para {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Você não pode viajar quando houver jogadores em seu esconderijo que não tenham concluído o tutorial do modo carreira."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Entrar no bate-papo"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Escreva uma mensagem..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Abrir bate-papo"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volume do microfone"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Empurre para falar"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/ro.json
+++ b/ro.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Nu poți deschide cufă până nu treci de tutorialul modului carieră."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Apăsați [{key}] pentru a {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Nu poți călători când există jucători în casa ta care nu au finalizat tutorialul pentru modul carieră."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Intră pe chat"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Scrie un mesaj..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Deschide chatul"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Volumul microfonului"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Apăsați pentru a vorbi"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/ru.json
+++ b/ru.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Вы не сможете открыть сундук, пока не пройдете обучение в режиме карьеры."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Вы не можете путешествовать, если в вашем убежище есть игроки, которые не прошли обучение по режиму карьеры."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Войти в чат"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Напишите сообщение..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Открыть чат"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Громкость микрофона"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Нажмите, чтобы поговорить"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/sv.json
+++ b/sv.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Du kan inte öppna kistan förrän du har klarat karriärlägeshandledningen."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Tryck på [{key}] för att {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Du kan inte resa när det finns spelare i ditt safehouse som inte har slutfört handledningen för karriärläge."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Gå in i chatten"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Skriv ett meddelande..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Öppna chatt"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofonvolym"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Tryck för att prata"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/th.json
+++ b/th.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "คุณไม่สามารถเปิดหีบได้จนกว่าคุณจะผ่านบทช่วยสอนโหมดอาชีพ."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "คุณไม่สามารถเดินทางได้เมื่อมีผู้เล่นในเซฟเฮาส์ของคุณที่ยังทำการฝึกสอนโหมดอาชีพไม่สำเร็จ."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "เข้าแชท"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "เขียนข้อความ..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "เปิดแชท"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "ระดับเสียงไมโครโฟน"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "กดเพื่อพูดคุย"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/tr.json
+++ b/tr.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Kariyer modu eğitimini geçene kadar sandığı açamazsınız."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "{interact} için [{key}] tuşuna basın"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Güvenli evinizde kariyer modu eğitimini tamamlamamış oyuncular varken seyahat edemezsiniz."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Sohbete girin"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Bir mesaj yazın..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Sohbeti aç"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Mikrofon ses seviyesi"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Konuşmak için bas"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/uk.json
+++ b/uk.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Ви не можете відкрити скриню, доки не пройдете підручник режиму кар'єри."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Натисніть [{key}], щоб {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Ви не можете подорожувати, якщо у вашому безпечному місці є гравці, які не пройшли підручник для режиму кар’єри."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Увійти в чат"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Написати повідомлення..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Відкрити чат"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Гучність мікрофона"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Натисни і говори"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/vi.json
+++ b/vi.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "Bạn không thể mở rương cho đến khi vượt qua hướng dẫn chế độ nghề nghiệp."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "Nhấn [{key}] để {interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "Bạn không thể đi du lịch khi có những người chơi trong nhà an toàn của bạn chưa hoàn thành hướng dẫn về chế độ nghề nghiệp."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "Nhập cuộc trò chuyện"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "Viết tin nhắn..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "Mở trò chuyện"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "Âm lượng micrô"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "Nhấn để nói chuyện"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "在通過職業模式教學之前你無法打開寶箱."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "按 [{key}] 進行{interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "當你的安全屋裡有未完成職業模式教學的玩家時，你無法旅行."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "進入聊天室"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "寫一則訊息..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "打開聊天"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "麥克風音量"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "一鍵通話"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",

--- a/zh.json
+++ b/zh.json
@@ -3,7 +3,7 @@
         "key": "9F428B644FC340682C8E35A9365C2E1D",
         "location": "/Game/Blueprints/crateInventory.crateInventory_C:ExecuteUbergraph_crateInventory [Script Bytecode]",
         "id": "You can't open the chest until you pass the career mode tutorial.",
-        "str": ""
+        "str": "在通过职业模式教程之前你无法打开宝箱."
     },
     {
         "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -2169,7 +2169,7 @@
         "key": "F0DAF05B4516E86912D72FB6CF221CE9",
         "location": "/Game/functions/messageFunctions.messageFunctions_C:getPressText [Script Bytecode]",
         "id": "Press [{key}] to {interact}",
-        "str": ""
+        "str": "按 [{key}] 进行{interact}"
     },
     {
         "key": "C158D252413F592114D488BB11C8055E",
@@ -2637,7 +2637,7 @@
         "key": "29AEF2C34EFF95CC9931F9BFDE3A81A6",
         "location": "/Game/UI/career/careerUI.careerUI_C:ExecuteUbergraph_careerUI [Script Bytecode]",
         "id": "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode.",
-        "str": ""
+        "str": "当你的安全屋里有未完成职业模式教程的玩家时，你无法旅行."
     },
     {
         "key": "3E89DE624ACBA88C4179C9852E9C70AD",
@@ -2907,13 +2907,13 @@
         "key": "53601F8C474D490D252A5AB16AC0B004",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Enter chat",
-        "str": ""
+        "str": "进入聊天室"
     },
     {
         "key": "CBE66CF34A90B013DD19BCB8455D256A",
         "location": "/Game/UI/chat.chat_C:GetHintText [Script Bytecode]",
         "id": "Write a message...",
-        "str": ""
+        "str": "写一条消息..."
     },
     {
         "key": "522202404C57B5F403ECFCA2EAAFE5A9",
@@ -3729,7 +3729,7 @@
         "key": "19D7C22E45997888F2982DAE095D995E",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_59.Text",
         "id": "Open chat",
-        "str": ""
+        "str": "打开聊天"
     },
     {
         "key": "6DA6B9C44E1E6E888DE71D887FCB9FFC",
@@ -3741,13 +3741,13 @@
         "key": "7B5E57D3450604279BB59E97C7B84E38",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_61.Text",
         "id": "Microphone volume",
-        "str": ""
+        "str": "麦克风音量"
     },
     {
         "key": "C12D675E4F2DCB6DD3AE108F78AE04AD",
         "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_62.Text",
         "id": "Push to talk",
-        "str": ""
+        "str": "一键通话"
     },
     {
         "key": "BC06960A474C65DE361B3CB2C89626B3",


### PR DESCRIPTION
This pull request includes translations for various strings in multiple language files. The changes primarily involve adding translations for user interface text and in-game messages.

### Arabic (`ar.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "Press [{key}] to {interact}"
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."
* Added translation for "Enter chat" and "Write a message..."
* Added translation for "Open chat", "Microphone volume", and "Push to talk" [[1]](diffhunk://#diff-ae56790a4765a3852450ecf4e880769f9fd7cb752c2c287ddef8f904a4798cc4L3732-R3732) [[2]](diffhunk://#diff-ae56790a4765a3852450ecf4e880769f9fd7cb752c2c287ddef8f904a4798cc4L3744-R3750)

### Bulgarian (`bg.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "Press [{key}] to {interact}"
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."
* Added translation for "Enter chat" and "Write a message..."
* Added translation for "Open chat", "Microphone volume", and "Push to talk" [[1]](diffhunk://#diff-b4daadc687eac661ca5c2629fb82fa0e6b31a1b432a633c300e7cb8d57861b98L3732-R3732) [[2]](diffhunk://#diff-b4daadc687eac661ca5c2629fb82fa0e6b31a1b432a633c300e7cb8d57861b98L3744-R3750)

### Czech (`cs.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "Press [{key}] to {interact}"
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."
* Added translation for "Enter chat" and "Write a message..."
* Added translation for "Open chat", "Microphone volume", and "Push to talk" [[1]](diffhunk://#diff-dd2253f9178515dc6077d3ee2d8254ec8926e88439b4f7bc4266065024464b18L3732-R3732) [[2]](diffhunk://#diff-dd2253f9178515dc6077d3ee2d8254ec8926e88439b4f7bc4266065024464b18L3744-R3750)

### Danish (`da.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "Press [{key}] to {interact}"
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."
* Added translation for "Enter chat" and "Write a message..."
* Added translation for "Open chat", "Microphone volume", and "Push to talk" [[1]](diffhunk://#diff-ad1ac0b8ef8eb3f9110255d38c6e7164b0b57b8ba93040be00e4401ba83c677bL3732-R3732) [[2]](diffhunk://#diff-ad1ac0b8ef8eb3f9110255d38c6e7164b0b57b8ba93040be00e4401ba83c677bL3744-R3750)

### German (`de.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."
* Added translation for "Enter chat" and "Write a message..."
* Added translation for "Open chat", "Microphone volume", and "Push to talk" [[1]](diffhunk://#diff-bf9f786abb4596863940d0995d897b3d67e217a61903685dd3486933ce573e0bL3732-R3732) [[2]](diffhunk://#diff-bf9f786abb4596863940d0995d897b3d67e217a61903685dd3486933ce573e0bL3744-R3750)

### Greek (`el.json`):
* Added translation for "You can't open the chest until you pass the career mode tutorial."
* Added translation for "Press [{key}] to {interact}"
* Added translation for "You cannot travel when there are players in your safehouse who have not completed the tutorial for career mode."