### PR TITLE
feat: new sentences

### DIFF
--- a/ar.json
+++ b/ar.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "استخدم المحتال التضليل من خلال انتحال شخصية {doll} لمدة ساعة وقام بالإجراء {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} يغادر اللعبة"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "انضم {player} إلى اللعبة"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "صديق"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "ميت"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "الدم في القضية"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "حالة الزجاج المكسور"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "العدو"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "حب"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "يكره"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "لم يعجبني / شطب"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "قد لا يكون الصندوق مرتبطًا بالدمية التي تقوم بالحركة، بل بدمية أخرى تم نقلها إلى هناك سابقًا."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/bg.json
+++ b/bg.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Измамникът е използвал заблуда, като се е представял като {doll} в продължение на един час и е извършил действието {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} напуска играта"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} се присъедини към играта"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "приятел"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Мъртъв"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Кръв в калъфа"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Витрина със счупено стъкло"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "враг"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "любов"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "омраза"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Не ми харесва/Задраскано"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Кутията може да не е свързана с куклата, изпълняваща действието, а с друга кукла, която е била преместена там по-рано."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/cs.json
+++ b/cs.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Podvodník použil klam tím, že se hodinu vydával za {doll} a provedl akci {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} opustit hru"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} se připojil ke hře"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "příteli"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Mrtvý"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Krev v pouzdru"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Rozbité skleněné pouzdro"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Nepřítel"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Láska"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Nenávist"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Nelíbí se/přeškrtnuto"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Krabice nemusí souviset s panenkou provádějící akci, ale s jinou panenkou, která tam byla přesunuta dříve."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/da.json
+++ b/da.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Bedrageren brugte vildlede ved at udgive sig som {doll} i en time og udførte handlingen {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} forlader spillet"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} deltog i spillet"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Ven"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Død"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Blod i sagen"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Knust glaskasse"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Fjende"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Kærlighed"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Had"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Kan ikke lide/overstreget"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Boksen er muligvis ikke relateret til dukken, der udfører handlingen, men til en anden dukke, der blev flyttet dertil tidligere."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/de.json
+++ b/de.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Der Betrüger täuschte sich, indem er sich eine Stunde lang als {doll} ausgab und die Aktion {action}. ausführte."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} verlässt das Spiel"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} ist dem Spiel beigetreten"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Freund"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Tot"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Blut im Koffer"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Zerbrochenes Glasgehäuse"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Feind"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Liebe"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Hassen"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Nicht gefallen/durchgestrichen"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Das Kästchen bezieht sich möglicherweise nicht auf die Puppe, die die Aktion ausführt, sondern auf eine andere Puppe, die zuvor dorthin verschoben wurde."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/el.json
+++ b/el.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Ο απατεώνας χρησιμοποίησε την παραπλάνηση παρουσιάζοντας ως {doll} για μια ώρα και εκτέλεσε την ενέργεια {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "Ο {player} αποχωρήσει από το παιχνίδι"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "Ο {player} μπήκε στο παιχνίδι"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Φίλε"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Νεκρός"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Αίμα στην υπόθεση"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Σπασμένη γυάλινη θήκη"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Εχθρός"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Αγάπη"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Μισώ"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Δεν μου άρεσε/Διαγράφηκε"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Το κουτί μπορεί να μην σχετίζεται με την κούκλα που εκτελεί την ενέργεια, αλλά με μια άλλη κούκλα που είχε μεταφερθεί εκεί νωρίτερα."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/es.json
+++ b/es.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "El impostor usó engaños haciéndose pasar por {doll} durante una hora y realizó la acción {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} abandona el juego"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} se unió al juego"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "amigo"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Muerto"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "sangre en el caso"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Caja de vidrio roto"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Enemigo"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Amar"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Odiar"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "No me gustó/tachado"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Es posible que la caja no esté relacionada con el muñeco que realiza la acción, sino con otro muñeco que se movió allí antes."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/fi.json
+++ b/fi.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Huijari käytti harhaanjohtamista esiintymällä tunnin ajan {doll} ja suoritti toiminnon {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} poistuu pelistä"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} liittyi peliin"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "ystävä"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Kuollut"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Veri kotelossa"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Rikkoutunut lasikotelo"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Vihollinen"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Rakkaus"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Viha"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Ei tykännyt / yliviivattu"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Laatikko ei ehkä liity toimintoa suorittavaan nukeen, vaan toiseen nukkeon, joka on siirretty sinne aiemmin."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/fr.json
+++ b/fr.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "L'imposteur a induit en erreur en se faisant passer pour une {doll} pendant une heure et a exécuté l'action {action}.."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} quitte le jeu"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} a rejoint le jeu"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Ami"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Mort"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Du sang dans l'affaire"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Boitier en verre brisé"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Ennemi"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Amour"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Détester"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Je n'ai pas aimé/Barré"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "La boîte n'est peut-être pas liée à la poupée effectuant l'action, mais à une autre poupée qui y a été déplacée plus tôt."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/hu.json
+++ b/hu.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "A csaló félrevezetve egy órán keresztül {doll}-nak adta ki magát, és végrehajtotta a következő műveletet: {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} hagyja el a játékot"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} csatlakozott a játékhoz"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Barát"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Halott"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Vér az ügyben"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Törött üvegház"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Ellenség"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Szeretet"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Gyűlölet"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Nem tetszett/Kihúzva"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Lehet, hogy a doboz nem a műveletet végrehajtó babához kapcsolódik, hanem egy másik babához, amelyet korábban áthelyeztek oda."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/id.json
+++ b/id.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Penipu tersebut menyesatkan dengan menyamar sebagai {doll} selama satu jam dan melakukan tindakan {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} keluar dari permainan"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} bergabung dalam permainan"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Teman"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Mati"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Darah dalam kasus ini"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Kotak kaca pecah"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Musuh"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Cinta"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Membenci"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Tidak Disukai/Dicoret"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Kotak itu mungkin tidak berhubungan dengan boneka yang melakukan aksi tersebut, tetapi dengan boneka lain yang dipindahkan ke sana sebelumnya."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/it.json
+++ b/it.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "L'impostore ha ingannato fingendosi {doll} per un'ora ed ha eseguito l'azione {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} lascia il gioco"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} si è unito al gioco"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Amico"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Morto"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Sangue nella custodia"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Vetrina rotta"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Nemico"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Amore"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Odio"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Non mi è piaciuto/Cancellato"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "La scatola potrebbe non essere correlata alla bambola che esegue l'azione, ma a un'altra bambola che è stata spostata lì in precedenza."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/ja.json
+++ b/ja.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "詐欺師は 1 時間にわたって {doll} を装って誤解を招き、{action}. というアクションを実行しました。"
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} がゲームから退出します"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} がゲームに参加しました"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "友達"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "死んだ"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "ケースの中の血"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "割れたガラスケース"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "敵"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "愛"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "嫌い"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "嫌い/取り消し線"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "箱はアクションを実行している人形に関連しているのではなく、以前にそこに移動された別の人形に関連している可能性があります."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/ko.json
+++ b/ko.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "사기꾼은 한 시간 동안 {doll}으로 가장하여 오해를 불러일으키고 {action}. 작업을 수행했습니다."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player}이(가) 게임에서 나가요"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player}이(가) 게임에 참여했습니다"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "친구"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "죽은"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "사건의 피"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "깨진 유리 케이스"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "적"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "사랑"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "싫어하다"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "싫어함/줄을 그어 지움"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "상자는 동작을 수행하는 인형과 관련이 없을 수도 있지만 이전에 그곳으로 옮겨진 다른 인형과 관련이 있을 수도 있습니다."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/nl.json
+++ b/nl.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "De bedrieger gebruikte misleiding door zich een uur lang voor te doen als {doll} en voerde de actie uit {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} verlaat het spel"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} heeft meegedaan aan het spel"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Vriend"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Dood"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Bloed in de zaak"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Gebroken glazen kast"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Vijand"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Liefde"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Haat"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Niet leuk gevonden/doorgestreept"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Het kan zijn dat de doos geen verband houdt met de pop die de actie uitvoert, maar met een andere pop die daar eerder naartoe is verplaatst."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/no.json
+++ b/no.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Bedrageren brukte villede ved å utgi seg som {doll} i en time og utførte handlingen {action}__PUNKT__"
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} forlater spillet"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} ble med i spillet"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Venn"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Død"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Blod i saken"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Knust glasskasse"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Fiende"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Kjærlighet"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Hat"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Likte ikke/overkrysset"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Boksen er kanskje ikke relatert til dukken som utfører handlingen, men til en annen dukke som ble flyttet dit tidligere."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/pl.json
+++ b/pl.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Oszust wprowadził w błąd, udając {doll} przez godzinę i wykonał akcję {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} opuść grę"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} dołączył do gry"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Przyjaciel"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Martwy"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Krew w tej sprawie"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Rozbita szklana obudowa"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Wróg"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Miłość"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Nienawidzić"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Nie podoba mi się/przekreślony"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Pudełko może nie być powiązane z lalką wykonującą akcję, ale z inną lalką, która została tam wcześniej przeniesiona."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/pt.json
+++ b/pt.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "O impostor enganou se passando por {doll} por uma hora e executou a ação {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} sai do jogo"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} entrou no jogo"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Amigo"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Morto"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Sangue no caso"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Caixa de vidro quebrada"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Inimigo"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Amor"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Odiar"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Não gostei/riscado"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "A caixa pode não estar relacionada ao boneco que está realizando a ação, mas a outro boneco que foi movido para lá anteriormente."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/ro.json
+++ b/ro.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Impostorul a folosit să inducă în eroare dându-se drept {doll} timp de o oră și a efectuat acțiunea {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} părăsește jocul"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} s-a alăturat jocului"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Prietene"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Mort"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Sânge în caz"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Carcasă din sticlă spartă"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Inamic"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Dragoste"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Ură"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Ne-a plăcut/Tasat"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Cutia poate să nu fie legată de păpușa care efectuează acțiunea, ci de o altă păpușă care a fost mutată acolo mai devreme."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/ru.json
+++ b/ru.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Самозванец ввел в заблуждение, изображая из себя {doll} в течение часа, и выполнил действие {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} выходит из игры"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} присоединился к игре"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Друг"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Мертвый"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Кровь в деле"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Разбитый стеклянный корпус"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Враг"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Любовь"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Ненавидеть"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Не понравилось/вычеркнуто"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Коробка может относиться не к кукле, выполняющей действие, а к другой кукле, которую туда переместили ранее."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/sv.json
+++ b/sv.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Bedragaren använde vilseleda genom att posera som {doll} i en timme och utförde åtgärden {action}__PUNKT__"
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} lämna spelet"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} gick med i spelet"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Vän"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Död"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Blod i fallet"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Krossad glaslåda"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Fiende"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Kärlek"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Hat"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Ogillade/Sträckt över"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Lådan kanske inte är relaterad till dockan som utför åtgärden, utan till en annan docka som flyttades dit tidigare."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/th.json
+++ b/th.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "ผู้แอบอ้างใช้การทำให้เข้าใจผิดโดยสวมรอยเป็น {doll} เป็นเวลาหนึ่งชั่วโมงแล้วจึงดำเนินการ {action."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} ออกจากเกม"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} เข้าร่วมเกม"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "เพื่อน"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "ตาย"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "เลือดในกรณี"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "เคสกระจกแตก"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "ศัตรู"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "รัก"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "เกลียด"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "ไม่ชอบ/ขีดฆ่าออก"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "กล่องอาจไม่เกี่ยวข้องกับตุ๊กตาที่กำลังแสดงท่าทาง แต่เป็นตุ๊กตาตัวอื่นที่ถูกย้ายไปที่นั่นก่อนหน้านี้."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/tr.json
+++ b/tr.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Sahtekar bir saat boyunca {doll} gibi davranarak yanıltmaya çalıştı ve {action}. eylemini gerçekleştirdi"
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} oyundan ayrıl"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} oyuna katıldı"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Arkadaş"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Ölü"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Davada kan"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Kırık cam kasa"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Düşman"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Aşk"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Nefret"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Beğenilmedi/Üzeri Çizildi"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Kutu, eylemi gerçekleştiren oyuncak bebekle değil, daha önce oraya taşınan başka bir oyuncak bebekle ilişkili olabilir."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/uk.json
+++ b/uk.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Самозванець ввів в оману, видаючи себе за {doll} протягом години та виконав дію {action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} залишає гру"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} приєднався до гри"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Друг"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Мертвий"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Кров у футлярі"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Розбита скляна вітрина"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Ворог"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "кохання"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "ненависть"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Не сподобалось/Викреслено"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Коробка може бути пов’язана не з лялькою, яка виконує дію, а з іншою лялькою, яку туди перемістили раніше."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/vi.json
+++ b/vi.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "Kẻ mạo danh đã đánh lừa bằng cách đóng giả {doll} trong một giờ và thực hiện hành động {action."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} rời khỏi trò chơi"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} đã tham gia trò chơi"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "Bạn bè"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "Chết"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "Máu trong vụ án"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "Vỏ kính vỡ"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "Kẻ thù"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "Yêu"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "Ghét"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "Không thích/Bỏ qua"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "Chiếc hộp có thể không liên quan đến con búp bê đang thực hiện hành động đó mà liên quan đến một con búp bê khác đã được chuyển đến đó trước đó."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "冒名頂替者冒充{doll}一小時誤導，並執行動作{action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} 離開遊戲"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} 加入了遊戲"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "朋友"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "死的"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "案子裡有血"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "破碎的玻璃盒"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "敵人"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "愛"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "恨"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "不喜歡/劃掉"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "盒子可能與執行該動作的玩偶無關，而是與之前移到那裡的另一個玩偶相關."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",

--- a/zh.json
+++ b/zh.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": ""
+    "str": "冒名顶替者冒充{doll}一小时进行误导，并执行动作{action}."
   },
   {
     "key": "9F428B644FC340682C8E35A9365C2E1D",
@@ -147,7 +147,7 @@
     "key": "313664F547D8F4158BB67E8898134C0E",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} leave the game",
-    "str": ""
+    "str": "{player} 离开游戏"
   },
   {
     "key": "8098B1CA4AED33E029A8D4878EE21A49",
@@ -177,7 +177,7 @@
     "key": "E260B86E4EF0F3E2B1480B8784D99A9A",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:ExecuteUbergraph_HorrorEngineGameMode [Script Bytecode]",
     "id": "{player} joined the game",
-    "str": ""
+    "str": "{player} 加入了游戏"
   },
   {
     "key": "F83E76BC49FC84244322C382556B6E5F",
@@ -3087,55 +3087,55 @@
     "key": "5ADF115E421CC60065765BA497935F74",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_1.Text",
     "id": "Friend",
-    "str": ""
+    "str": "朋友"
   },
   {
     "key": "EAB84FBB483ADA0AE254B58FE13593EA",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_10.Text",
     "id": "Dead",
-    "str": ""
+    "str": "死的"
   },
   {
     "key": "A8E3F4F94BF11CC640BC06949C1574D2",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_11.Text",
     "id": "Blood in the case",
-    "str": ""
+    "str": "案子里有血"
   },
   {
     "key": "4DFBCFF84F6ABD25D8A1EEAC828D4EED",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_12.Text",
     "id": "Broken glass case",
-    "str": ""
+    "str": "破碎的玻璃盒"
   },
   {
     "key": "194B739B4C7AA8D2F830669466E77A1F",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_2.Text",
     "id": "Enemy",
-    "str": ""
+    "str": "敌人"
   },
   {
     "key": "1D8FD7BF41336E508A0C819D98D92E5C",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_3.Text",
     "id": "Love",
-    "str": ""
+    "str": "爱"
   },
   {
     "key": "5F725F7240D646C0E28BA6BCB803C985",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_4.Text",
     "id": "Hate",
-    "str": ""
+    "str": "恨"
   },
   {
     "key": "B1CD68AA49EED6E1F88A3E87FFBC3F83",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.Text_5.Text",
     "id": "Disliked/Crossed Out",
-    "str": ""
+    "str": "不喜欢/划掉"
   },
   {
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": ""
+    "str": "该盒子可能与执行该动作的玩偶无关，而是与之前移到那里的另一个玩偶相关."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",


### PR DESCRIPTION
This pull request includes updates to the localization files for several languages, adding translations for various game-related strings.

Translations added:

* `ar.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"
  * Added translations for various terms in the UI details legend, such as "Friend", "Dead", "Blood in the case", and more

* `bg.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"
  * Added translations for various terms in the UI details legend, such as "Friend", "Dead", "Blood in the case", and more

* `cs.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"
  * Added translations for various terms in the UI details legend, such as "Friend", "Dead", "Blood in the case", and more

* `da.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"
  * Added translations for various terms in the UI details legend, such as "Friend", "Dead", "Blood in the case", and more

* `de.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"
  * Added translations for various terms in the UI details legend, such as "Friend", "Dead", "Blood in the case", and more

* `el.json`:
  * Added translation for "The impostor used mislead by posing as {doll} for an hour and performed the action {action}."
  * Added translation for "{player} leave the game"
  * Added translation for "{player} joined the game"