### PR TITLE
feat: multiplayer sentence

### DIFF
--- a/ar.json
+++ b/ar.json
@@ -2268,6 +2268,12 @@
     "str": "كلمة المرور غير صحيحة"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "لا يمكنك الانضمام إلى مباراة متعددة اللاعبين حتى تكمل البرنامج التعليمي."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/bg.json
+++ b/bg.json
@@ -2268,6 +2268,12 @@
     "str": "Паролата е неправилна"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Не можете да се присъедините към мултиплейър мач, докато не завършите урока."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/cs.json
+++ b/cs.json
@@ -2268,6 +2268,12 @@
     "str": "Heslo je nesprávné"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "完成教學後才能加入多人比賽。"
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/da.json
+++ b/da.json
@@ -2268,6 +2268,12 @@
     "str": "Adgangskoden er forkert"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Du kan ikke deltage i en multiplayer-kamp, før du har gennemført tutorialen."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/de.json
+++ b/de.json
@@ -2268,6 +2268,12 @@
     "str": "Das Passwort ist falsch"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Sie können einem Mehrspieler-Match erst beitreten, wenn Sie das Tutorial abgeschlossen haben."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/el.json
+++ b/el.json
@@ -2268,6 +2268,12 @@
     "str": "Ο κωδικός πρόσβασης είναι λανθασμένος"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Δεν μπορείτε να συμμετάσχετε σε ένα παιχνίδι για πολλούς παίκτες μέχρι να ολοκληρώσετε το σεμινάριο."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/en.json
+++ b/en.json
@@ -2268,6 +2268,12 @@
     "str": "Password is incorrect"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "You can't join a multiplayer match until you complete the tutorial."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/es.json
+++ b/es.json
@@ -2268,6 +2268,12 @@
     "str": "La contraseña es incorrecta"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "No puedes unirte a una partida multijugador hasta que completes el tutorial."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/fi.json
+++ b/fi.json
@@ -2268,6 +2268,12 @@
     "str": "Salasana on väärä"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Et voi liittyä moninpelimatsiin ennen kuin olet suorittanut tutoriaalin."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/fr.json
+++ b/fr.json
@@ -2268,6 +2268,12 @@
     "str": "Le Mot de Passe est incorrecte"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Vous ne pouvez pas rejoindre une partie multijoueur avant d'avoir terminé le didacticiel."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/hu.json
+++ b/hu.json
@@ -2268,6 +2268,12 @@
     "str": "A jelszó helytelen"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Nem csatlakozhatsz többjátékos mérkőzéshez, amíg be nem fejezed az oktatót."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/id.json
+++ b/id.json
@@ -2268,6 +2268,12 @@
     "str": "Kata sandi salah"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Anda tidak dapat bergabung dalam pertandingan multipemain sampai Anda menyelesaikan tutorial."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/it.json
+++ b/it.json
@@ -2268,6 +2268,12 @@
     "str": "La password non è corretta"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Non puoi partecipare a una partita multiplayer finché non completi il tutorial."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/ja.json
+++ b/ja.json
@@ -2268,6 +2268,12 @@
     "str": "パスワードが間違っています"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "チュートリアルを完了するまで、マルチプレイヤーマッチには参加できません。"
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/ko.json
+++ b/ko.json
@@ -2268,6 +2268,12 @@
     "str": "비밀번호가 올바르지 않습니다."
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "튜토리얼을 완료하기 전에는 멀티플레이어 매치에 참여할 수 없습니다."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/nl.json
+++ b/nl.json
@@ -2268,6 +2268,12 @@
     "str": "Wachtwoord is onjuist"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Je kunt niet deelnemen aan een multiplayerwedstrijd voordat je de tutorial hebt voltooid."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/no.json
+++ b/no.json
@@ -2268,6 +2268,12 @@
     "str": "Passordet er feil"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Du kan ikke bli med i en flerspillerkamp før du har fullført veiledningen."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/pl.json
+++ b/pl.json
@@ -2268,6 +2268,12 @@
     "str": "Hasło jest nieprawidłowe"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Nie możesz dołączyć do meczu wieloosobowego, dopóki nie ukończysz samouczka."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/pt.json
+++ b/pt.json
@@ -2268,6 +2268,12 @@
     "str": "A senha está incorreta"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Você não pode entrar em uma partida multiplayer até concluir o tutorial."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/ro.json
+++ b/ro.json
@@ -2268,6 +2268,12 @@
     "str": "Parola este incorectă"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Nu poți intra într-un meci multiplayer până nu termini tutorialul."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/ru.json
+++ b/ru.json
@@ -2268,6 +2268,12 @@
     "str": "Неверный пароль"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Вы не можете присоединиться к многопользовательскому матчу, пока не завершите обучение."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/sv.json
+++ b/sv.json
@@ -2268,6 +2268,12 @@
     "str": "Lösenordet är felaktigt"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Du kan inte gå med i en multiplayer-match förrän du har slutfört handledningen."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/th.json
+++ b/th.json
@@ -2268,6 +2268,12 @@
     "str": "รหัสผ่านไม่ถูกต้อง"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "คุณไม่สามารถเข้าร่วมการแข่งขันแบบผู้เล่นหลายคนได้จนกว่าจะเสร็จสิ้นบทช่วยสอน"
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/tr.json
+++ b/tr.json
@@ -2268,6 +2268,12 @@
     "str": "Şifre yanlış"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Eğitimi tamamlamadan çok oyunculu bir maça katılamazsınız."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/uk.json
+++ b/uk.json
@@ -2268,6 +2268,12 @@
     "str": "Пароль неправильний"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Ви не можете приєднатися до багатокористувацького матчу, доки не завершите навчання."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/vi.json
+++ b/vi.json
@@ -2268,6 +2268,12 @@
     "str": "Mật khẩu không đúng"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "Bạn không thể tham gia trận đấu nhiều người chơi cho đến khi hoàn thành hướng dẫn."
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -2268,6 +2268,12 @@
     "str": "密碼不正確"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "完成教學後才能加入多人比賽。"
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",

--- a/zh.json
+++ b/zh.json
@@ -2268,6 +2268,12 @@
     "str": "密码错误"
   },
   {
+    "key": "7C05B2D1458BF9056EFE4A98BF9D4544",
+    "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
+    "id": "You can't join a multiplayer match until you complete the tutorial.",
+    "str": "完成教程后才能加入多人比赛。"
+  },
+  {
     "key": "EC2A6CF342794100347D079D5C709865",
     "location": "/Game/functions/netFunctions.netFunctions_C:canJoinInSession [Script Bytecode]",
     "id": "The lobby is full",


### PR DESCRIPTION
This pull request includes updates to multiple localization files to add a new string for the message "You can't join a multiplayer match until you complete the tutorial." The changes ensure that this message is properly translated and available in various languages.

Localization updates:

* [`ar.json`](diffhunk://#diff-ae56790a4765a3852450ecf4e880769f9fd7cb752c2c287ddef8f904a4798cc4R2270-R2275): Added the translation for the message "You can't join a multiplayer match until you complete the tutorial."
* [`bg.json`](diffhunk://#diff-b4daadc687eac661ca5c2629fb82fa0e6b31a1b432a633c300e7cb8d57861b98R2270-R2275): Added the translation for the message "You can't join a multiplayer match until you complete the tutorial."
* [`cs.json`](diffhunk://#diff-dd2253f9178515dc6077d3ee2d8254ec8926e88439b4f7bc4266065024464b18R2270-R2275): Added the translation for the message "You can't join a multiplayer match until you complete the tutorial."
* [`da.json`](diffhunk://#diff-ad1ac0b8ef8eb3f9110255d38c6e7164b0b57b8ba93040be00e4401ba83c677bR2270-R2275): Added the translation for the message "You can't join a multiplayer match until you complete the tutorial."
* [`de.json`](diffhunk://#diff-bf9f786abb4596863940d0995d897b3d67e217a61903685dd3486933ce573e0bR2270-R2275): Added the translation for the message "You can't join a multiplayer match until you complete the tutorial."

These changes ensure that the new message is available in Arabic, Bulgarian, Czech, Danish, and German, among other languages.