### PR TITLE
feat: toggle lock

### DIFF
--- a/ar.json
+++ b/ar.json
@@ -2874,12 +2874,6 @@
     "str": "أصدقاء"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "خلف"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "حجم الروبوت"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "تبديل القفل"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/bg.json
+++ b/bg.json
@@ -2874,12 +2874,6 @@
     "str": "приятели"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Назад"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Обем на робота"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Превключване на заключването"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/cs.json
+++ b/cs.json
@@ -2874,12 +2874,6 @@
     "str": "Přátelé"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Zadní"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Objem robota"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Přepnout zámek"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/da.json
+++ b/da.json
@@ -2874,12 +2874,6 @@
     "str": "Venner"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Tilbage"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotvolumen"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Skift lås"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/de.json
+++ b/de.json
@@ -2874,12 +2874,6 @@
     "str": "Freunde"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Zurück"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotervolumen"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Sperre umschalten"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/el.json
+++ b/el.json
@@ -2874,12 +2874,6 @@
     "str": "Φίλοι"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Πίσω"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Τόμος ρομπότ"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Εναλλαγή κλειδώματος"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/en.json
+++ b/en.json
@@ -2874,12 +2874,6 @@
     "str": "Friends"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Back"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robot Volume"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Toggle lock"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/es.json
+++ b/es.json
@@ -2874,12 +2874,6 @@
     "str": "Amigos"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Volver"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volumen del robot"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Alternar bloqueo"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/fi.json
+++ b/fi.json
@@ -2874,12 +2874,6 @@
     "str": "Ystävät"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Takaisin"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotin tilavuus"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Vaihda lukitus"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/fr.json
+++ b/fr.json
@@ -2874,12 +2874,6 @@
     "str": "Amis"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Retour"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volume des robots"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Basculer le verrou"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/hu.json
+++ b/hu.json
@@ -2874,12 +2874,6 @@
     "str": "Barátok"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Vissza"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robot kötet"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Zár kapcsolása"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/id.json
+++ b/id.json
@@ -2874,12 +2874,6 @@
     "str": "Teman-teman"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Kembali"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volume Robotnya"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Alihkan kunci"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/it.json
+++ b/it.json
@@ -2874,12 +2874,6 @@
     "str": "Amici"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Indietro"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volume del robot"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Attiva/disattiva blocco"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/ja.json
+++ b/ja.json
@@ -2874,12 +2874,6 @@
     "str": "友達"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "戻る"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "ロボットのボリューム"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "ロックの切り替え"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/ko.json
+++ b/ko.json
@@ -2874,12 +2874,6 @@
     "str": "친구"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "뒤쪽에"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "로봇 볼륨"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "잠금 전환"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/nl.json
+++ b/nl.json
@@ -2874,12 +2874,6 @@
     "str": "Vrienden"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Terug"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotvolume"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Vergrendeling schakelen"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/no.json
+++ b/no.json
@@ -2874,12 +2874,6 @@
     "str": "Venner"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Tilbake"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotvolum"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Bytt lås"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/pl.json
+++ b/pl.json
@@ -3,7 +3,7 @@
     "key": "100DA204405F9111E1C236B3FF176270",
     "location": "/Game/Blueprints/actionExecute.actionExecute_C:ExecuteUbergraph_actionExecute [Script Bytecode]",
     "id": "The impostor used mislead by posing as {doll} for an hour and performed the action {action}.",
-    "str": "Impostor wprowadził w błąd, udając {doll} przez godzinę i wykonał akcję {action}."
+    "str": "Oszust wprowadził w błąd, udając {doll} przez godzinę i wykonał akcję {action}."
   },
   {
     "key": "8C6EFCE649B93D5275B158901F4CAB7A",
@@ -201,7 +201,7 @@
     "key": "0525435A4091E8021EFF0D8B98CE9BC4",
     "location": "/Game/Blueprints/HorrorEngineGameMode.HorrorEngineGameMode_C:isCorrectImpostor [Script Bytecode]",
     "id": "Wrong impostor",
-    "str": "Zły impostor"
+    "str": "Zły oszust"
   },
   {
     "key": "416137A54D8BDF2957A99DA3E3A214DB",
@@ -567,7 +567,7 @@
     "key": "ADEEDBE04D10D55BE7B838934AC45E6C",
     "location": "/Game/data-tables/itemList.itemList.NewRow_2.info_16_4DFA58E54C75086154A8DC9A319FD10E",
     "id": "Activate the final battle to uncover the impostor.",
-    "str": "Aktywuj ostateczną bitwę, aby odkryć impostora."
+    "str": "Aktywuj ostateczną bitwę, aby odkryć oszusta."
   },
   {
     "key": "CA5357694E9708D4AC84699C2DC77CBD",
@@ -1629,7 +1629,7 @@
     "key": "E60C061E42EEE57516BA1B83B2A64C7E",
     "location": "/Game/enums/probability.probability.DisplayNameMap(2 - Value).DisplayNameMap",
     "id": "Normal",
-    "str": "Normalny"
+    "str": "Normalna"
   },
   {
     "key": "9404939C41414F86FA16B8B0C5B74E9D",
@@ -2343,7 +2343,7 @@
     "key": "BC337B2B42B2192B0CEC87925C1BFA2C",
     "location": "/Game/levels/safeMap.safeMap:PersistentLevel.helpInformation_C_1.description",
     "id": "Doll Who is a deduction board game where two players try to guess the identity of the character chosen by their opponent. Each player has a board with a series of characters with different traits. By asking yes or no questions about the characters' features (such as whether they have a hat or appeared in the daycare map), players eliminate options until they discover the opponent's character. The first player to guess correctly wins.",
-    "str": "Doll Who to gra planszowa typu dedukcyjnego, w której dwóch graczy stara się odgadnąć tożsamość postaci wybranej przez przeciwnika. Każdy gracz ma planszę z szeregiem postaci o różnych cechach. Zadając pytania, na które można odpowiedzieć \\\\\"tak\\\\\" lub \\\\\"nie\\\\\" (np. czy postać ma kapelusz lub pojawiła się na mapie przedszkola), gracze eliminują opcje, aż odkryją postać przeciwnika. Pierwszy gracz, który zgadnie poprawnie, wygrywa."
+    "str": "Doll Who to gra planszowa typu dedukcyjnego, w której dwóch graczy stara się odgadnąć tożsamość postaci wybranej przez przeciwnika. Każdy gracz ma planszę z szeregiem postaci o różnych cechach. Zadając pytania, na które można odpowiedzieć \n\n\n\n\ntak\n\n\n\n\n\n lub \n\n\n\n\nie\n\n\n\n\n\n (np. czy postać ma kapelusz lub pojawiła się na mapie przedszkola), gracze eliminują opcje, aż odkryją postać przeciwnika. Pierwszy gracz, który zgadnie poprawnie, wygrywa."
   },
   {
     "key": "7ABFF0E544D6C598A2E7A08FC98250AC",
@@ -2367,7 +2367,7 @@
     "key": "04119A0C4BAB3896CA5F208DA41F582A",
     "location": "/Game/levels/tutorialMap.tutorialMap_C:ExecuteUbergraph_tutorialMap [Script Bytecode]",
     "id": "It looks like the impostor has done some events. These will be displayed on your left panel. Review them and then access the room again.",
-    "str": "Wygląda na to, że impostor dokonał pewnych zmian w pokoju. Zostaną one wyświetlone na lewej tablicy. Przejrzyj je, a następnie ponownie wejdź do pokoju."
+    "str": "Wygląda na to, że oszust dokonał pewnych zmian w pokoju. Zostaną one wyświetlone na lewej tablicy. Przejrzyj je, a następnie ponownie wejdź do pokoju."
   },
   {
     "key": "08FC22B7498C0918FE50E0AB274B5889",
@@ -2379,7 +2379,7 @@
     "key": "095285C644BBCF6CF4EA8EBA3F985F9F",
     "location": "/Game/levels/tutorialMap.tutorialMap_C:ExecuteUbergraph_tutorialMap [Script Bytecode]",
     "id": "This is the dolls' room. Here you will see what they have done while you slept. Take a look at them, and then let's go back to the room.",
-    "str": "To jest pokój lalek. Tutaj zobaczysz, co zrobiły, podczas gdy spałeś. Przyjrzyj się im a następnie wróćmy do pokoju z tablicami."
+    "str": "To jest pokój lalek. Tutaj zobaczysz, co zrobiły, podczas gdy spałeś. Przyjrzyj się im następnie wróćmy do pokoju. z tablicami"
   },
   {
     "key": "0A3D5EC2435134BB35A189A4B69C4101",
@@ -2439,19 +2439,19 @@
     "key": "6621BA854D50DB36041E58AFE9A250D5",
     "location": "/Game/levels/tutorialMap.tutorialMap_C:ExecuteUbergraph_tutorialMap [Script Bytecode]",
     "id": "It's the last hour. We only have this chance to find out. Let's go to the room.",
-    "str": "Została nam godzina, to nasza ostatnia szansa, aby odnaleźć impostora! Chodźmy do pokoju."
+    "str": "Została nam godzina, to nasza ostatnia szansa, aby odnaleźć oszusta! Chodźmy do pokoju."
   },
   {
     "key": "75DB907D4C3E80ED887ACDA2AADF602C",
     "location": "/Game/levels/tutorialMap.tutorialMap_C:ExecuteUbergraph_tutorialMap [Script Bytecode]",
     "id": "You will have a detective role in which you will have to determine, based on the impostor's likes and dislikes listed on the panel to your left, what he likes and doesn't like, who his enemies, friends, loves, or hated individuals are.",
-    "str": "Będziesz pełnić rolę detektywa, w której na podstawie upodobań i niechęci impostora wymienionych na panelu po twojej lewej stronie będziesz musiał określić, co lubi i czego nie lubi, kto jest jego wrogiem, przyjacielem, miłością lub znienawidzoną osobą."
+    "str": "Będziesz pełnił rolę detektywa, w której  lubi, a czego nie, kim sbędziesz musiał określić, na podstawie upodobań oszusta wymienionych na tablicy po lewej stronie, kim są jego wrogowie, przyjaciele, osoby które kocha oraz nienawidzi."
   },
   {
     "key": "7F18D69F420F68627730E39CE489A2EC",
     "location": "/Game/levels/tutorialMap.tutorialMap_C:ExecuteUbergraph_tutorialMap [Script Bytecode]",
     "id": "Let's set a trap for the impostor. We already know that he likes TV and music. Turn on the lights.",
-    "str": "Zastawmy pułapkę na impostora. Już wiemy, że lubi telewizję i muzykę. Włącz światło."
+    "str": "Zastawmy pułapkę na oszusta. Już wiemy, że lubi telewizję i muzykę. Włącz światło."
   },
   {
     "key": "815797D840D1A6AEC45401A9A3996DE0",
@@ -2874,12 +2874,6 @@
     "str": "Przyjaciele"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Powrót"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -3021,7 +3015,7 @@
     "key": "FEFFD2EC495732A7FB2D3083906B98F9",
     "location": "/Game/UI/detailsLegend.detailsLegend_C:WidgetTree.TextBlock.Text",
     "id": "The box might not be related to the doll performing the action, but to another doll that was moved there earlier.",
-    "str": "Skrzynka może nie być związana z lalką wykonującą akcję, a z inną lalką, która została tam przeniesiona wcześniej."
+    "str": " Skrzynka może nie być związana z lalką wykonującą akcję, a z inną lalką, która została tam przeniesiona wcześniej."
   },
   {
     "key": "EF9484874E9B2D923F2B00B2C0CAAF9D",
@@ -3123,7 +3117,7 @@
     "key": "7C43F9DE48DB63CDFAC71F9F14D83E23",
     "location": "/Game/UI/gameMenu.gameMenu_C:WidgetTree.TextBlock_10.Text",
     "id": "Only suitable for professionals, it starts at 08:00 and only has 3 effective clues, there are no photos or aids, some of the data is hidden, you have limited access to the map",
-    "str": "Tylko dla profesjonalistów; zaczynasz o 08:00, masz zaledwie 3 skuteczne wskazówki, brak zdjęć i innych pomocy. Część danych jest ukryta, a dostęp do mapy jest ograniczony."
+    "str": " Tylko dla profesjonalistów; zaczynasz o 08:00, masz zaledwie 3 skuteczne wskazówki, brak zdjęć i innych pomocy. Część danych jest ukryta, a dostęp do mapy jest ograniczony."
   },
   {
     "key": "95E8DAF7441719B3063BE7B84B85AE87",
@@ -3255,7 +3249,7 @@
     "key": "6540E66F480EE470D56246880E1AAC02",
     "location": "/Game/UI/gameMenu.gameMenu_C:WidgetTree.TextBlock_9.Text",
     "id": "The standard difficulty for each player, all clues will be made at 08:00, you have the option to see the names of the dolls and the list of actions of the imposter",
-    "str": "Standardowy poziom trudności dla każdego gracza, wszystkie wskazówki będą udostępniane o 08:00, masz możliwość zobaczenia nazw lalek oraz listy działań impostora"
+    "str": "Standardowy poziom trudności dla każdego gracza, wszystkie wskazówki będą udostępniane o 08:00, masz możliwość zobaczenia nazw lalek oraz listy działań oszusta"
   },
   {
     "key": "41A1A89A4ADCC9D9F94EABA4A93A05DB",
@@ -3393,7 +3387,7 @@
     "key": "6F0469EB48D6EC34F0C511B2D187D7D9",
     "location": "/Game/UI/linkRefs.linkRefs_C:WidgetTree.TextBlock_1.Text",
     "id": "Have you had any issues?",
-    "str": "Napotkałeś jakieś problemy?"
+    "str": "Czy miałeś jakieś problemy?"
   },
   {
     "key": "A2C08BE6447E2720D3051F8CA460E102",
@@ -3471,7 +3465,7 @@
     "key": "A0C0892943CF5FC4B208879116F465F0",
     "location": "/Game/UI/results.results_C:WidgetTree.TextBlock_13.Text",
     "id": "Impostor Selected",
-    "str": "Wybrano impostora"
+    "str": "Wybrano oszusta"
   },
   {
     "key": "FEEFC0A44A89E6CC7163CEB1F9C3F1B8",
@@ -3501,7 +3495,7 @@
     "key": "EDD9076E4875FB9F12D9D790EC0CE5B6",
     "location": "/Game/UI/results.results_C:WidgetTree.TextBlock_41.Text",
     "id": "You have lost 75% for not discovering the impostor",
-    "str": "Straciłeś 75% całej nagrody za to, że nie odkryłeś impostora"
+    "str": "Straciłeś 75% całej nagrody za to, że nie odkryłeś oszusta"
   },
   {
     "key": "B03E1FBA436DD65AC1BDFB9C7CED0AAE",
@@ -4077,7 +4071,7 @@
     "key": "054AC4C746C09AD57CA9C497A131F64F",
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_63.Text",
     "id": "Show Press key to interact",
-    "str": "Pokaż naciśnij klawisz, aby wejść w interakcję"
+    "str": "Pokaż Naciśnij klawisz, aby wejść w interakcję"
   },
   {
     "key": "DFC00BD04359DBA0F8F0DF9D8825DBF3",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Głośność robota"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Przełącz blokadę"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",
@@ -4191,7 +4191,7 @@
     "key": "EBE268F84D4CEBE50AAF908A7823DF79",
     "location": "/Game/UI/todoList.todoList_C:WidgetTree.dislikes_2.Text",
     "id": "Find the imposter and keep it in the bag",
-    "str": "Znajdź impostora i trzymaj go w torbie"
+    "str": "Znajdź oszusta i trzymaj go w torbie"
   },
   {
     "key": "7B34A441429642B9DA52218285A1BB2A",
@@ -4209,7 +4209,7 @@
     "key": "BFD9681847D40C8577B0C49731F23FF8",
     "location": "/Game/UI/todoList.todoList_C:WidgetTree.soulbook.Text",
     "id": "Use the Book of Souls to Identify the Imposter",
-    "str": "Skorzystaj z Księgi Dusz, aby zidentyfikować impostora"
+    "str": "Skorzystaj z Księgi Dusz, aby zidentyfikować oszusta"
   },
   {
     "key": "8204CCFA44B783AD08234F8DE4E4D11B",
@@ -4257,7 +4257,7 @@
     "key": "B383AEBA444328B5A71FF88EF36A0DBB",
     "location": "/Game/UI/winDetails.winDetails_C:WidgetTree.DefaultSpinner.Options(1).Options.Label",
     "id": "Impostor",
-    "str": "Impostor"
+    "str": "Oszust"
   },
   {
     "key": "E447809B421298C1BDA5E4B063D86F49",

--- a/pt.json
+++ b/pt.json
@@ -2874,12 +2874,6 @@
     "str": "Amigos"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Voltar"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volume do Robô"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Alternar bloqueio"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/ro.json
+++ b/ro.json
@@ -2874,12 +2874,6 @@
     "str": "Prieteni"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Spate"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Volumul robotului"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Comutare blocare"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/ru.json
+++ b/ru.json
@@ -2874,12 +2874,6 @@
     "str": "Друзья"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Назад"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Объем робота"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Переключить замок"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/sv.json
+++ b/sv.json
@@ -2874,12 +2874,6 @@
     "str": "Vänner"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Tillbaka"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robotvolym"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Växla lås"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/th.json
+++ b/th.json
@@ -2874,12 +2874,6 @@
     "str": "เพื่อน"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "กลับ"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "ปริมาณหุ่นยนต์"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "สลับการล็อก"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/tr.json
+++ b/tr.json
@@ -2874,12 +2874,6 @@
     "str": "Arkadaşlar"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Geri"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Robot Hacmi"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Kilidi değiştir"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/uk.json
+++ b/uk.json
@@ -2874,12 +2874,6 @@
     "str": "друзі"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Назад"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Том роботи"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Перемикання блокування"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/vi.json
+++ b/vi.json
@@ -2874,12 +2874,6 @@
     "str": "Bạn"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "Mặt sau"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "Khối lượng robot"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "Chuyển đổi khóa"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/zh-TW.json
+++ b/zh-TW.json
@@ -2874,12 +2874,6 @@
     "str": "朋友"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "返回"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "機器人體積"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "切換鎖定"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",

--- a/zh.json
+++ b/zh.json
@@ -2874,12 +2874,6 @@
     "str": "好友"
   },
   {
-    "key": "56EBFA974C38A9B5F563D3A75E5BF0E0",
-    "location": "/Game/UI/career/historyCases.historyCases_C:WidgetTree.TextBlock_11.Text",
-    "id": "Back",
-    "str": "返回"
-  },
-  {
     "key": "A213AE2B42DEEB0AC450A9AEC96730E1",
     "location": "/Game/UI/career/ticketItem.ticketItem_C:WidgetTree.TextBlock_11.Text",
     "id": "Closed",
@@ -4120,6 +4114,12 @@
     "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_70.Text",
     "id": "Robot Volume",
     "str": "机器人体积"
+  },
+  {
+    "key": "4B42EDC74552B167B6C050B42EED7773",
+    "location": "/Game/UI/settings.settings_C:WidgetTree.TextBlock_71.Text",
+    "id": "Toggle lock",
+    "str": "切换锁定"
   },
   {
     "key": "7826866B435A8EE313772C8979CA261B",


### PR DESCRIPTION
This pull request involves updates to various localization files, specifically removing the "Back" translation entry and adding a new "Toggle lock" entry across multiple languages.

Changes to localization files:

* Removed the "Back" translation entry from `ar.json`, `bg.json`, `cs.json`, `da.json`, `de.json`, `el.json`, `en.json`, `es.json`, `fi.json`, `fr.json`, `hu.json`, `id.json`, `it.json`, `ja.json`, `ko.json`, `nl.json`, and `no.json`. 
  * Example: `"id": "Back", "str": "خلف"` was removed from `ar.json`.
  
* Added the "Toggle lock" translation entry to `ar.json`, `bg.json`, `cs.json`, `da.json`, `de.json`, `el.json`, `en.json`, `es.json`, `fi.json`, `fr.json`, `hu.json`, `id.json`, `it.json`, `ja.json`, `ko.json`, `nl.json`, and `no.json`.
  * Example: `"id": "Toggle lock", "str": "تبديل القفل"` was added to `ar.json`.